### PR TITLE
Respect parent UIView bounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ uibutton-activity
 
 UIButton that displays an activity indicator when disabled.
 
+This fork makes sure the indicator is always at the center.
+
 Demo
 ====
 

--- a/UIButton+Activity.podspec
+++ b/UIButton+Activity.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "UIButton+Activity"
-  s.version          = "1.0.1"
+  s.version          = "1.0.2"
   s.summary          = "UIButton that displays an activity indicator when disabled."
   s.homepage         = "https://github.com/needbee/uibutton-activity"
   s.license          = 'MIT'

--- a/src/UIButton+Activity.m
+++ b/src/UIButton+Activity.m
@@ -43,6 +43,11 @@
     [self updateActivityIndicatorVisibility];
 }
 
+-(void)setBounds:(CGRect)bounds {
+    [super setBounds:bounds];
+    [self.spinner setCenter:CGPointMake(self.bounds.size.width/2, self.bounds.size.height/2)];
+}
+
 -(UIActivityIndicatorView *)spinner {
     UIActivityIndicatorView *result;
     


### PR DESCRIPTION
Hi.
I've overriden -setBounds: to make sure activity indicator always stays in the center.